### PR TITLE
WAT-21

### DIFF
--- a/src/Message/UserUpdate.php
+++ b/src/Message/UserUpdate.php
@@ -13,7 +13,7 @@ class UserUpdate extends AbstractMessage
 {
     const EMAIL_PARAM_NAME = 'email';
     const DAW_PARAM_NAME = 'daw';
-    const HARDWARE_PARAM_NAME = 'hardware';
+    const DJ_HARDWARE_PARAM_NAME = 'dj_hardware';
     const LANGUAGE_PARAM_NAME = 'language';
     const COUNTRY_PARAM_NAME = 'country';
 
@@ -56,22 +56,22 @@ class UserUpdate extends AbstractMessage
     }
 
     /**
-     * Set user hardware
+     * Set user DJ hardware
      * @param string $hardware
      * @return UserUpdate
      */
-    public function setHardware($hardware)
+    public function setDjHardware($hardware)
     {
-        return $this->setParam(self::HARDWARE_PARAM_NAME, $hardware);
+        return $this->setParam(self::DJ_HARDWARE_PARAM_NAME, $hardware);
     }
 
     /**
-     * Get user hardware
+     * Get user DJ hardware
      * @return string
      */
-    public function getHardware()
+    public function getDjHardware()
     {
-        return $this->getParam(self::HARDWARE_PARAM_NAME);
+        return $this->getParam(self::DJ_HARDWARE_PARAM_NAME);
     }
 
     /**

--- a/tests/Message/UserUpdateTest.php
+++ b/tests/Message/UserUpdateTest.php
@@ -18,13 +18,13 @@ class UserUpdateTest extends PHPUnitTestCase
         $userUpdate = UserUpdate::create($userId)
                         ->setEmail($email)
                         ->setDaw($daw)
-                        ->setHardware($hardware)
+                        ->setDjHardware($hardware)
                         ->setLanguage($language)
                         ->setCountry($country);
 
         $this->assertEquals($email, $userUpdate->getEmail());
         $this->assertEquals($daw, $userUpdate->getDaw());
-        $this->assertEquals($hardware, $userUpdate->getHardware());
+        $this->assertEquals($hardware, $userUpdate->getDjHardware());
         $this->assertEquals($language, $userUpdate->getLanguage());
         $this->assertEquals($country, $userUpdate->getCountry());
     }


### PR DESCRIPTION
Rename `Serato\UserProfileSdk\Message\UserUpdate` accessor and setter properties.

* Rename `UserUpdate::setHardware` to `UserUpdate::setDjHardware`
* Rename `UserUpdate::getHardware` to `UserUpdate::getDjHardware`