### PR TITLE
WAT-21

### DIFF
--- a/src/Message/UserUpdate.php
+++ b/src/Message/UserUpdate.php
@@ -13,7 +13,7 @@ class UserUpdate extends AbstractMessage
 {
     const EMAIL_PARAM_NAME = 'email';
     const DAW_PARAM_NAME = 'daw';
-    const DJ_HARDWARE_PARAM_NAME = 'dj_hardware';
+    const HAS_DJ_HARDWARE_PARAM_NAME = 'dj_hardware';
     const LANGUAGE_PARAM_NAME = 'language';
     const COUNTRY_PARAM_NAME = 'country';
 
@@ -56,22 +56,22 @@ class UserUpdate extends AbstractMessage
     }
 
     /**
-     * Set user DJ hardware
-     * @param string $hardware
+     * Sets whether or not the user has DJ hardware
+     * @param bool $hardware
      * @return UserUpdate
      */
-    public function setDjHardware($hardware)
+    public function setHasDjHardware($hardware)
     {
-        return $this->setParam(self::DJ_HARDWARE_PARAM_NAME, $hardware);
+        return $this->setParam(self::HAS_DJ_HARDWARE_PARAM_NAME, $hardware);
     }
 
     /**
-     * Get user DJ hardware
-     * @return string
+     * Returns whether or not the user has DJ hardware
+     * @return bool
      */
-    public function getDjHardware()
+    public function getHasDjHardware()
     {
-        return $this->getParam(self::DJ_HARDWARE_PARAM_NAME);
+        return $this->getParam(self::HAS_DJ_HARDWARE_PARAM_NAME);
     }
 
     /**

--- a/tests/Message/UserUpdateTest.php
+++ b/tests/Message/UserUpdateTest.php
@@ -11,20 +11,20 @@ class UserUpdateTest extends PHPUnitTestCase
         $userId = 123;
         $email = 'test@serato.com';
         $daw = 'dawOption';
-        $hardware = 'intro';
+        $hardware = true;
         $language = 'en';
         $country = 'US';
 
         $userUpdate = UserUpdate::create($userId)
                         ->setEmail($email)
                         ->setDaw($daw)
-                        ->setDjHardware($hardware)
+                        ->setHasDjHardware($hardware)
                         ->setLanguage($language)
                         ->setCountry($country);
 
         $this->assertEquals($email, $userUpdate->getEmail());
         $this->assertEquals($daw, $userUpdate->getDaw());
-        $this->assertEquals($hardware, $userUpdate->getDjHardware());
+        $this->assertEquals($hardware, $userUpdate->getHasDjHardware());
         $this->assertEquals($language, $userUpdate->getLanguage());
         $this->assertEquals($country, $userUpdate->getCountry());
     }


### PR DESCRIPTION
Rename `Serato\UserProfileSdk\Message\UserUpdate` accessor and setter properties.

* Rename `UserUpdate::setDjHardware` to `UserUpdate::setHasDjHardware`
* Rename `UserUpdate::getDjHardware` to `UserUpdate::getHasDjHardware`